### PR TITLE
Version 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 os: osx
 language: node_js
 node_js:
+  - '16'
   - '14'
   - '12'
-  - '10'
 script:
   - npm run lint
   - npm run test-ci

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+comment:
+  layout: "diff, files"
+  require_changes: true
+coverage:
+  status:
+    patch:
+      default:
+        threshold: 5%

--- a/package.json
+++ b/package.json
@@ -38,18 +38,17 @@
     "shell",
     "terminal"
   ],
-  "dependencies": {},
   "devDependencies": {
-    "chai": "^4.2.0",
-    "codecov": "^3.8.1",
-    "eslint": "^7.13.0",
-    "eslint-plugin-prettier": "^3.1.4",
-    "mocha": "^8.2.1",
+    "chai": "^4.3.4",
+    "codecov": "^3.8.3",
+    "eslint": "^8.6.0",
+    "eslint-plugin-prettier": "^4.0.0",
+    "mocha": "^9.1.3",
     "nyc": "^15.1.0",
-    "prettier": "^2.1.2"
+    "prettier": "^2.5.1"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "preferGlobal": true,
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mac-trash",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Zero-dependency macOS CLI tool to move files to the Trash",
   "author": "Johan Satgé",
   "bin": {

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ This project uses [semver](http://semver.org/).
 
 | Version | Date | Notes |
 | --- | --- | --- |
+| `2.0.0` | 2022-01-08 | Rework deletion method, update deps, update Node support (#1) |
 | `1.0.1` | 2020-11-15 | Fix CLI initialization |
 | `1.0.0` | 2020-11-15 | Initial version |
 

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@
 
 ## Installation
 
-_This module needs Node `>=10`._
+_This module needs Node `>=12`._
 
 Install with [npm](https://www.npmjs.com/):
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -82,7 +82,7 @@ async function checkFileIsWritable(filePath) {
 }
 
 async function getHfsPath(posixPath) {
-  const escapedPath = posixPath.replaceAll('"', '\\\\\\"')
+  const escapedPath = posixPath.replace(/"/g, '\\\\\\"')
   const osascript = `tell application \\"Finder\\" to return posix file \\"${escapedPath}\\"`
   const { stdout } = await executeCommand(`/usr/bin/osascript -e "${osascript}"`)
   const hfsPath = stdout.match(/^file (.*)/)

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,8 +2,11 @@
 
 const exec = require('child_process').exec
 const path = require('path')
+const fs = require('fs')
+const os = require('os')
 const fsp = require('fs').promises
 const { style } = require('./style.js')
+const pkg = require('../package.json')
 const { showVersionAndExit, showHelpAndExit } = require('./help.js')
 
 const cliFlags = ['--verbose', '--help', '--version']
@@ -12,53 +15,93 @@ const filesList = process.argv.slice(2).filter((arg) => !cliFlags.includes(arg))
 
 if (process.argv.includes('--version')) {
   showVersionAndExit()
-} else if (process.argv.includes('--help') || filesList.length === 0) {
+}
+if (process.argv.includes('--help') || filesList.length === 0) {
   showHelpAndExit()
 }
 
 run()
 
 async function run() {
-  let trashedFiles = 0
+  // Create a list of hfs paths ("Macintosh HD:someDir:someFile")
+  // from the user input (POSIX paths "/someDir/someFile")
+  const hfsFiles = []
   for (const file of filesList) {
-    const absPath = path.resolve(process.cwd(), file)
     try {
-      await checkFileExists(absPath)
-      await trashFile(absPath)
-      trashedFiles += 1
+      const absPosixPath = path.resolve(process.cwd(), file)
+      await checkFileIsWritable(absPosixPath)
+      hfsFiles.push(await getHfsPath(absPosixPath))
     } catch (error) {
-      console.log(`Could not trash ${style.red(file)} (${error.message})`)
+      console.log(`Will not trash ${style.red(file)} (${error.message})`)
     }
   }
-  const trashedFilesCount = `${trashedFiles} ${trashedFiles === 1 ? 'file' : 'files'}`
+  // Generate a temporary JS script and run it with osascript
+  // (Running osascript -e [expression] could cause buffer overflow if too many files)
+  try {
+    const scriptPath = await generateTrashScript(hfsFiles)
+    await executeTrashScript(scriptPath)
+    await deleteTrashScript(scriptPath)
+  } catch (error) {
+    console.log(`Trash error (${style.red(error.message)})`)
+  }
+  const trashedFilesCount = `${hfsFiles.length} ${hfsFiles.length === 1 ? 'file' : 'files'}`
   console.log(`Moved ${style.cyan(trashedFilesCount)} to the Trash. 🗑️`)
 }
 
-async function trashFile(filePath) {
+async function generateTrashScript(hfsFiles) {
+  verbose(`Generating trash script from ${hfsFiles.length} items`)
+  const scriptPath = path.join(os.tmpdir(), `${pkg.name}.${Date.now()}.${Math.random()}.js`)
+  // Running a JS script instead of AppleScript to be able to pass a JSON array with files
+  // Note finder.delete() seems to only accept HFS paths, not POSIX paths, hence the conversion above
+  const script = `const finder = Application('Finder')\nfinder.delete(${JSON.stringify(hfsFiles)})`
+  verbose(script)
+  await fsp.writeFile(scriptPath, script, 'utf8')
+  return scriptPath
+}
+
+async function executeTrashScript(scriptPath) {
+  const shellCommand = `/usr/bin/osascript -l JavaScript ${scriptPath}`
+  verbose(`Executing trash script (${shellCommand})`)
+  const { stdout, stderr } = await executeCommand(shellCommand)
+  verbose(`Stdout: ${stdout.trim()}`)
+  verbose(`Stderr: ${stderr.trim()}`)
+}
+
+async function deleteTrashScript(scriptPath) {
+  verbose(`Deleting trash script (${scriptPath})`)
+  await fsp.unlink(scriptPath)
+}
+
+async function checkFileIsWritable(filePath) {
+  verbose(`Checking if "${filePath}" is writable`)
+  try {
+    await fsp.stat(filePath, fs.constants.W_OK)
+  } catch (error) {
+    throw new Error('File not writable')
+  }
+}
+
+async function getHfsPath(posixPath) {
+  const escapedPath = posixPath.replaceAll('"', '\\\\\\"')
+  const osascript = `tell application \\"Finder\\" to return posix file \\"${escapedPath}\\"`
+  const { stdout } = await executeCommand(`/usr/bin/osascript -e "${osascript}"`)
+  const hfsPath = stdout.match(/^file (.*)/)
+  if (!hfsPath) {
+    throw new Error('Could not find HFS path')
+  }
+  return hfsPath[1].trim()
+}
+
+function executeCommand(command) {
   return new Promise((resolve, reject) => {
-    const osascript = `tell application \\"Finder\\" to delete POSIX file \\"${filePath}\\"`
-    const shellCommand = `/usr/bin/osascript -e "${osascript}"`
-    if (isVerbose) {
-      console.log(`Running ${shellCommand}`)
-    }
-    exec(shellCommand, (error, stdout, stderr) => {
-      if (isVerbose) {
-        console.log(`Error: ${error ? error.message : 'none'}`)
-        console.log(`Stdout: ${stdout.trim()}`)
-        console.log(`Stderr: ${stderr.trim()}`)
-      }
-      error ? reject(error) : resolve()
+    exec(command, (error, stdout, stderr) => {
+      error ? reject(error) : resolve({ stdout, stderr })
     })
   })
 }
 
-async function checkFileExists(filePath) {
-  try {
-    if (isVerbose) {
-      console.log(`Checking if "${filePath}" exists`)
-    }
-    await fsp.stat(filePath)
-  } catch (error) {
-    throw new Error('File not found')
+function verbose() {
+  if (isVerbose) {
+    console.log(...arguments)
   }
 }

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -22,7 +22,7 @@ describe('cli', function () {
   it('fails gracefully if the file cannot be moved to the Trash', async () => {
     const nonExistingFile = getRandomFilename()
     const { stdout, stderr } = await execMacTrashCli(nonExistingFile)
-    expect(stdout).to.contain('Could not trash')
+    expect(stdout).to.contain('Will not trash')
     expect(stdout).to.contain(nonExistingFile)
     expect(stderr).to.equal('')
   })
@@ -30,8 +30,7 @@ describe('cli', function () {
   it('outputs debug info with the --verbose flag', async () => {
     const { desktopPath } = await createTestFile()
     const { stdout, stderr } = await execMacTrashCli(`${desktopPath} --verbose`)
-    expect(stdout).to.contain('Running /usr/bin/osascript')
-    expect(stdout).to.contain('Error: none')
+    expect(stdout).to.contain('Executing trash script')
     expect(stdout).to.contain('Stdout:')
     expect(stdout).to.contain('Stderr:')
     expect(stdout).to.contain('.Trash')

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -37,7 +37,7 @@ async function fileExists(filePath) {
 }
 
 async function execMacTrashCli(args) {
-  args = args.replaceAll('"', '\\"')
+  args = args.replace(/"/g, '\\"')
   return new Promise((resolve, reject) => {
     const command = `node cli.js ${args}`
     exec(command, { cwd: path.join(__dirname, '..', 'src') }, (error, stdout, stderr) => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -24,7 +24,7 @@ async function createTestFile() {
 }
 
 function getRandomFilename() {
-  return `mac-trash-${crypto.randomBytes(12).toString('hex')}.txt`
+  return `mac-"trash"-${crypto.randomBytes(12).toString('hex')}.txt`
 }
 
 async function fileExists(filePath) {
@@ -37,6 +37,7 @@ async function fileExists(filePath) {
 }
 
 async function execMacTrashCli(args) {
+  args = args.replaceAll('"', '\\"')
   return new Promise((resolve, reject) => {
     const command = `node cli.js ${args}`
     exec(command, { cwd: path.join(__dirname, '..', 'src') }, (error, stdout, stderr) => {


### PR DESCRIPTION
- Rework deletion method so deleting multiple files pushes a single operation in the Finder history (`Cmd-Z` will restore all the files at once, instead of the last one only)
- Handle special chars such as `"` in paths
- Update dev deps
- Support Node 16, drop support for Node 10